### PR TITLE
Some refactoring and minor fixes

### DIFF
--- a/Ppress_Lib/Services/OLClientServiceBase.cs
+++ b/Ppress_Lib/Services/OLClientServiceBase.cs
@@ -58,7 +58,5 @@
                 throw new Exception("Unable to get service version");
             }
         }
-
-
     }
 }

--- a/Ppress_Lib/Services/OLOutputCreation.cs
+++ b/Ppress_Lib/Services/OLOutputCreation.cs
@@ -14,14 +14,16 @@
         private OLOutputCreation() : base(null, null)  { }
 
 
-        public async Task<bool> Process(int jobSetId, string outputPreset, Stream streamResult,
+        public async Task<bool> Process(string outputPresetPath, long jobSetId, Stream streamResult,
             OLEvents.SendEventHandler? processEvent = null,
             OLEvents.ProgressEventHandler? progressEvent = null)
         {
             EnsureSessionActive();
 
-            if ((jobSetId == 0) || string.IsNullOrEmpty(outputPreset))
-                throw new ArgumentException("OutputCreation Process: Bad arguments");
+            if (jobSetId <= 0 || string.IsNullOrEmpty(outputPresetPath))
+                throw new ArgumentException("JobCreation Process: Bad arguments");
+
+            long outputPresetId = await client.Services.FileStore.UploadFileAsync(outputPresetPath);
 
             if (processEvent != null) Onsend += processEvent;
             if (progressEvent != null) Onprogress += progressEvent;
@@ -30,12 +32,11 @@
             
             using (HttpClient http = client.GetHttpClientInstance())
             {
-                string _operationId = await SubmitAsync(http, jobSetId, outputPreset);
+                string _operationId = await SubmitAsync(http, outputPresetId, jobSetId);
 
                 await GetProgressAsync(http, _operationId);
 
                 _result = await GetResultAsync(http, _operationId, streamResult);
-
             }
 
 
@@ -43,17 +44,15 @@
             if (progressEvent != null) Onprogress -= progressEvent;
 
             return true;
-
-
         }
 
-        private async Task<string> SubmitAsync(HttpClient http, int jobSetId, string outputPreset)
+        private async Task<string> SubmitAsync(HttpClient http, long outputPresetId, long jobSetId)
         {
             string operationId;
 
             try
             {
-                HttpResponseMessage resp = await http.PostAsync($"{serviceUrl}{outputPreset}/{jobSetId}", null);
+                HttpResponseMessage resp = await http.PostAsync($"{serviceUrl}{outputPresetId}/{jobSetId}", null);
                 if (!resp.IsSuccessStatusCode) 
                     throw new Exception("OutputCreation can't process this action.");
                 if (!resp.Headers.TryGetValues("operationId", out IEnumerable<string>? values))
@@ -66,12 +65,10 @@
             {
                 throw new Exception("unable to process OutputCreation");
             }
-
         }
 
-        public async Task<string> GetResultAsync (HttpClient http,  string operationId, Stream streamResult)
+        public async Task<string> GetResultAsync (HttpClient http, string operationId, Stream streamResult)
         {
-
             try
             {
                 HttpResponseMessage resp = await http.PostAsync($"{serviceUrl}getResult/{operationId}", null);
@@ -82,7 +79,6 @@
                 {
                     await contentStream.CopyToAsync(streamResult);
                 }
-                
 
                 return "OK";
             }
@@ -92,7 +88,7 @@
             }
         }
 
-        public async Task<bool> GetProgressAsync (HttpClient http,  string operationId)
+        public async Task<bool> GetProgressAsync (HttpClient http, string operationId)
         {
             int retry = 0;
             bool done = false;


### PR DESCRIPTION
- Generalized UploadDataFile to support different file types. Each file type uses a different URL path and mimetype.
- All operations now handle file uploads automatically, for ease of use. This means they expect paths rather than ids.
- Fixed some inconsistencies that caused errors. For example, we can't pass a file path directly to content creation, the file needs to be uploaded first. Fixed the "persisent" typo.
- Fixed the problem mentioned in https://learn.objectiflune.com/discourse/t/c-rest-api-client-library/5558/4